### PR TITLE
Remove deprecated register modifier

### DIFF
--- a/Clp/src/CoinAbcCommon.hpp
+++ b/Clp/src/CoinAbcCommon.hpp
@@ -224,7 +224,7 @@ extern "C"
 #endif
 typedef unsigned char CoinCheckZero;
 template <class T> inline void
-CoinAbcMemset0(register T* to, const int size)
+CoinAbcMemset0(T* to, const int size)
 {
 #ifndef NDEBUG
   // Some debug so check
@@ -235,7 +235,7 @@ CoinAbcMemset0(register T* to, const int size)
   std::memset(to,0,size*sizeof(T));
 }
 template <class T> inline void
-CoinAbcMemcpy(register T* to, register const T* from, const int size )
+CoinAbcMemcpy(T* to, const T* from, const int size )
 {
 #ifndef NDEBUG
   // Some debug so check

--- a/CoinUtils/src/CoinHelperFunctions.hpp
+++ b/CoinUtils/src/CoinHelperFunctions.hpp
@@ -253,7 +253,7 @@ CoinCopyOfArrayOrZero( const T * array , const int size)
     alternative coding if USE_MEMCPY defined*/
 #ifndef COIN_USE_RESTRICT
 template <class T> inline void
-CoinMemcpyN(register const T* from, const int size, register T* to)
+CoinMemcpyN(const T* from, const int size, T* to)
 {
 #ifndef _MSC_VER
 #ifdef USE_MEMCPY

--- a/Osi/src/OsiCpx/OsiCpxSolverInterface.cpp
+++ b/Osi/src/OsiCpx/OsiCpxSolverInterface.cpp
@@ -1860,7 +1860,7 @@ void OsiCpxSolverInterface::setColSetBounds(const int* indexFirst,
    char* c = new char[2*cnt];
    int* ind = new int[2*cnt];
    for (int i = 0; i < cnt; ++i) {
-      register const int j = 2 * i;
+      const int j = 2 * i;
       c[j] = 'L';
       c[j+1] = 'U';
       const int colind = indexFirst[i];

--- a/Osi/test/OsiTestSolver.hpp
+++ b/Osi/test/OsiTestSolver.hpp
@@ -21,12 +21,12 @@
 #endif
 
 template <class T> static inline T
-VolMax(register const T x, register const T y) {
+VolMax(const T x, const T y) {
    return ((x) > (y)) ? (x) : (y);
 }
 
 template <class T> static inline T
-VolAbs(register const T x) {
+VolAbs(const T x) {
    return ((x) > 0) ? (x) : -(x);
 }
 
@@ -502,7 +502,7 @@ public:
 			const double alpha) {
       if (alpha < parm.alphamin)
 	 return 1.0;
-      register const double ll = VolAbs(lcost);
+      const double ll = VolAbs(lcost);
       const double x = ll > 10 ? (lcost-lastvalue)/ll : (lcost-lastvalue);
       lastvalue = lcost;
       return (x <= 0.01) ? parm.alphafactor : 1.0;


### PR DESCRIPTION
register modifier has been removed in C++17.

This has already been addressed upstream:

https://github.com/coin-or/Osi/commit/aa793506344bdac1a681b2535253bc782a4361fb

https://github.com/coin-or/Osi/commit/f05f459aad19bcb74a577723ac473cca2814fa3a

cc @fabiencastan 