### PR TITLE
Remove deprecated register modifier

### DIFF
--- a/CoinUtils/src/CoinOslFactorization2.cpp
+++ b/CoinUtils/src/CoinOslFactorization2.cpp
@@ -20,9 +20,9 @@
 extern int ets_count;
 extern int ets_check;
 #endif
-#define COIN_REGISTER register
+#define COIN_REGISTER
 #define COIN_REGISTER2
-#define COIN_REGISTER3 register
+#define COIN_REGISTER3
 #ifdef COIN_USE_RESTRICT
 # define COIN_RESTRICT2 __restrict
 #else


### PR DESCRIPTION
register modifier has been removed in C++17.

This has already been addressed upstream:

https://github.com/coin-or/CoinUtils/commit/1700ed92c2bc1562aabe65dee3b4885bd5c87fb9

cc @fabiencastan