### PR TITLE
Fix out of bounds write warning

### DIFF
--- a/Clp/src/ClpPdco.cpp
+++ b/Clp/src/ClpPdco.cpp
@@ -316,7 +316,7 @@ ClpPdco::pdco( ClpPdcoBase * stuff, Options &options, Info &info, Outfo &outfo)
      //bool useChol = (LSmethod == 1);
      //bool useQR   = (LSmethod == 2);
      bool direct  = (LSmethod <= 2 && ifexplicit);
-     char solver[6];
+     char solver[7];
      strcpy(solver, "  LSQR");
 
 


### PR DESCRIPTION
This is addressed upstream:

https://github.com/coin-or/Clp/commit/6e689f3ba509c90ca88d98ca33933e07eef86b8b

This also fixes build on systems where this warning is enabled with "-Werror" by default.