### PR TITLE
Fix -Wformat-security warning

### DIFF
--- a/CoinUtils/src/CoinMessageHandler.cpp
+++ b/CoinUtils/src/CoinMessageHandler.cpp
@@ -820,7 +820,7 @@ CoinMessageHandler::operator<< (double doublevalue)
 	  sprintf(messageOut_,g_format_,doublevalue);
 	  if (next != format_+2) {
 	    messageOut_+=strlen(messageOut_);
-	    sprintf(messageOut_,format_+2);
+	    sprintf(messageOut_,"%s",format_+2);
 	  }
 	}
 	messageOut_+=strlen(messageOut_);


### PR DESCRIPTION
Upstream code has been refactored and no longer has this issue.

This also fixes build on systems where this warning is enabled with "-Werror".